### PR TITLE
Fix a link of get_citations()

### DIFF
--- a/docs/clustering.html
+++ b/docs/clustering.html
@@ -253,7 +253,7 @@ plot_cells(cds, color_cells_by="plate", label_cell_groups=FALSE)
 {% endhighlight %}
       
 
-      <p>When run with the <code>alignment_group</code> argument, <code>align_cds()</code> tries to remove batch effects using <a href="https://doi.org/10.1038/nbt.4091">mutual nearest neighbor alignment</a>, a technique introduced by John Marioni's lab. Monocle 3 does so by calling Aaron Lun's excellent package <a href="https://bioconductor.org/packages/release/bioc/html/batchelor.html">batchelor</a>. If you use <code>align_cds()</code>, be sure to call <a href="{{ site.baseurl }}/monocle3_docs/#citations"><code>get_citations()</code></a> to see how you should cite the software on which Monocle depends. </p>
+      <p>When run with the <code>alignment_group</code> argument, <code>align_cds()</code> tries to remove batch effects using <a href="https://doi.org/10.1038/nbt.4091">mutual nearest neighbor alignment</a>, a technique introduced by John Marioni's lab. Monocle 3 does so by calling Aaron Lun's excellent package <a href="https://bioconductor.org/packages/release/bioc/html/batchelor.html">batchelor</a>. If you use <code>align_cds()</code>, be sure to call <a href="{{ site.baseurl }}/docs/citations/"><code>get_citations()</code></a> to see how you should cite the software on which Monocle depends. </p>
 
       
       <div class= "text-center">


### PR DESCRIPTION
The target sentence can be found in the
https://cole-trapnell-lab.github.io/monocle3/docs/clustering/#batch-effects
section.

Before: https://cole-trapnell-lab.github.io/monocle3/monocle3_docs/#citations
After:  https://cole-trapnell-lab.github.io/monocle3/docs/citations/