### PR TITLE
Fix quote markup

### DIFF
--- a/docs/trajectories.html
+++ b/docs/trajectories.html
@@ -231,7 +231,7 @@ plot_cells(cds,
           <p>
             By ordering each cell according to its progress along a learned trajectory, Monocle alleviates the problems that 
             arise due to asynchrony. Instead of tracking changes in expression as a function of time, Monocle tracks changes as 
-            a function of progress along the trajectory, which we term ``pseudotime''. Pseudotime is an abstract unit of progress: 
+            a function of progress along the trajectory, which we term "pseudotime". Pseudotime is an abstract unit of progress: 
             it's simply the distance between a cell and the start of the trajectory, measured along the shortest path. The 
             trajectory's total length is defined in terms of the total amount of transcriptional change that a cell undergoes as 
             it moves from the starting state to the end state.


### PR DESCRIPTION
\`...\` is a markup in Markdown. So \`\` is removed from rendered HTML.

In this change, simply "..." is used.

The rendered HTML:
https://cole-trapnell-lab.github.io/monocle3/docs/trajectories/#order-cells