### PR TITLE
Matrix.utils has been removed from CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,4 +90,5 @@ VignetteBuilder: knitr
 Language: en-US
 Remotes:
     VPetukhov/ggrastr,
+    cran/Matrix.utils,
     cole-trapnell-lab/leidenbase


### PR DESCRIPTION
You can temporarily use the read-only mirror until Matrix.utils is back on CRAN or has been removed from monocle3.