### PR TITLE
Added ability for aggregate_gene_expression to handle short gene names.

### DIFF
--- a/R/cluster_genes.R
+++ b/R/cluster_genes.R
@@ -145,9 +145,11 @@ my.aggregate.Matrix = function (x, groupings = NULL, form = NULL, fun = "sum", .
 #'
 #' @param cds The cell_data_set on which this function operates
 #' @param gene_group_df A dataframe in which the first column contains gene ids
-#'   and the second contains groups. If NULL, genes are not grouped.
+#'   or short gene names and the second contains groups. If NULL, genes are not
+#'   grouped.
 #' @param cell_group_df A dataframe in which the first column contains cell ids
-#'   and the second contains groups. If NULL, cells are not grouped.
+#'   or short gene names and the second contains groups. If NULL, cells are not
+#'   grouped.
 #' @param norm_method How to transform gene expression values before
 #'   aggregating them. If "log", a pseudocount is added. If "size_only", values
 #'   are divided by cell size factors prior to aggregation.
@@ -185,6 +187,17 @@ aggregate_gene_expression <- function(cds,
                                      fData(cds)$gene_short_name |
                                      gene_group_df[,1] %in%
                                      row.names(fData(cds)),,drop=FALSE]
+
+    # Convert gene short names to rownames if necessary. The more
+    # straightforward single call to recode took much longer.
+    short_name_mask <- gene_group_df[[1]] %in% fData(cds)$gene_short_name
+    if (any(short_name_mask)) {
+      geneids <- as.character(gene_group_df[[1]])
+      geneids[short_name_mask] <- row.names(fData(cds))[match(
+                  geneids[short_name_mask], fData(cds)$gene_short_name)]
+      gene_group_df[[1]] <- geneids
+    }
+
     # gene_group_df = gene_group_df[row.names(fData(cds)),]
 
     # FIXME: this should allow genes to be part of multiple groups. group_by


### PR DESCRIPTION
## Summary
This fixes issue #351, allowing gene_short_name's to be passed to `aggregate_gene_expression` in addition to updating the inline documentation. See that issue for additional details and the minimum working example.

This builds on my local machine (Windows 10) and successfully runs the MWE referenced in issue,  __but it fails__ testthat tests. However, the test failures seem independent of my modification; a sample of the test failures are included after possible improvements.

## Possible improvements
- Make the modification code prettier. I tried an alternative solution where I used dplyr's `recode` function, passing the first column of the `gene_group_df` and a named vector comprised of the `gene_short_name` and `id` columns of CDS. This was a nice two-liner, but it was _much_ slower (increasing the runtime of `aggregate_gene_expression` on my MWE by a factor of 3) than the current version that coerces to a character vector/directly substitutes.
- Add tests to the test suite that ensure that this behavior works.

### Test failures
```
-- 1. Failure: cluster_cells works (@test-cluster_cells.R#59)  -----------------
cds@clusters[["UMAP"]]$cluster_result$optim_res$membership[[1]] not equal to 9.
1/1 mismatches
[1] 12 - 9 == 3

-- 2. Failure: cluster_cells works (@test-cluster_cells.R#61)  -----------------
length(unique(clusters(cds, reduction_method = "UMAP"))) not equal to 20.
1/1 mismatches
[1] 18 - 20 == -2

-- 3. Failure: cluster_cells works (@test-cluster_cells.R#69)  -----------------
cds@clusters[["UMAP"]]$cluster_result$optim_res$membership[[1]] not equal to 3.
1/1 mismatches
[1] 4 - 3 == 1

-- 4. Failure: cluster_cells works (@test-cluster_cells.R#71)  -----------------
length(unique(clusters(cds, reduction_method = "UMAP"))) not equal to 10.
1/1 mismatches
[1] 9 - 10 == -1

Running louvain iteration  1 ...
  -Number of clusters: 11 
-- 5. Failure: cluster_cells works (@test-cluster_cells.R#81)  -----------------
cds@clusters[["UMAP"]]$cluster_result$optim_res$membership[[1]] not equal to 9.
1/1 mismatches
[1] 10 - 9 == 1
--snip--
-- 6. Failure: cluster_cells works (@test-cluster_cells.R#104)  ----------------
cds@clusters[["tSNE"]]$cluster_result$optim_res$membership[[1]] not equal to 10.
1/1 mismatches
[1] 1 - 10 == -9

-- 7. Failure: cluster_cells works (@test-cluster_cells.R#106)  ----------------
length(unique(clusters(cds, reduction_method = "tSNE"))) not equal to 20.
1/1 mismatches
[1] 18 - 20 == -2

8. Error: fit_models() returns correct output for negative binomial regressio
could not find function "object_size"
Backtrace:
 1. testthat::expect_lt(...)
 2. testthat::quasi_label(enquo(object), label, arg = "object")
 3. rlang::eval_bare(expr, quo_get_env(quo))

-- 9. Error: fit_models() returns correct output for Poisson regression (@test-f
could not find function "object_size"
Backtrace:
 1. testthat::expect_lt(...)
 2. testthat::quasi_label(enquo(object), label, arg = "object")
 3. rlang::eval_bare(expr, quo_get_env(quo))

-- 10. Error: fit_models() returns correct output for quasipoisson regression (@
could not find function "object_size"
Backtrace:
 1. testthat::expect_lt(...)
 2. testthat::quasi_label(enquo(object), label, arg = "object")
 3. rlang::eval_bare(expr, quo_get_env(quo))

-- 11. Error: fit_models() returns correct output for zero-inflated Poisson regr
could not find function "object_size"
Backtrace:
 1. testthat::expect_lt(...)
 2. testthat::quasi_label(enquo(object), label, arg = "object")
 3. rlang::eval_bare(expr, quo_get_env(quo))

-- 12. Error: fit_models() returns correct output for zero-inflated negative bin
could not find function "object_size"
Backtrace:
 1. testthat::expect_lt(...)
 2. testthat::quasi_label(enquo(object), label, arg = "object")
 3. rlang::eval_bare(expr, quo_get_env(quo))

-- 13. Failure: fit_models() can handle cluster in model formulae (@test-fit_mod
pos_ctrl_coefs$estimate[2] not equal to -0.9550378.
1/1 mismatches
[1] -0.208 - -0.955 == 0.747
```