### PR TITLE
fix typo `dim(genes) >= 2` 

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -139,7 +139,7 @@ plot_cells_3d <- function(cds,
   ## Marker genes
   markers_exprs <- NULL
   if (!is.null(genes)) {
-    if ((is.null(dim(genes)) == FALSE) && dim(genes) >= 2){
+    if ((is.null(dim(genes)) == FALSE) && ncol(genes) >= 2){
       markers <- unlist(genes[,1], use.names=FALSE)
     } else {
       markers <- genes
@@ -151,7 +151,7 @@ plot_cells_3d <- function(cds,
       cds_exprs <- SingleCellExperiment::counts(cds)[row.names(markers_rowData), ,drop=FALSE]
       cds_exprs <- Matrix::t(Matrix::t(cds_exprs)/size_factors(cds))
 
-      if ((is.null(dim(genes)) == FALSE) && dim(genes) >= 2){
+      if ((is.null(dim(genes)) == FALSE) && ncol(genes) >= 2){
         genes <- as.data.frame(genes)
         row.names(genes) <- genes[,1]
         genes <- genes[row.names(cds_exprs),]
@@ -566,7 +566,7 @@ plot_cells <- function(cds,
   markers_exprs <- NULL
   expression_legend_label <- NULL
   if (!is.null(genes)) {
-    if (!is.null(dim(genes)) && dim(genes) >= 2){
+    if (!is.null(dim(genes)) && ncol(genes) >= 2){
       markers = unlist(genes[,1], use.names=FALSE)
     } else {
       markers = genes
@@ -581,7 +581,7 @@ plot_cells <- function(cds,
       cds_exprs <- SingleCellExperiment::counts(cds)[row.names(markers_rowData), ,drop=FALSE]
       cds_exprs <- Matrix::t(Matrix::t(cds_exprs)/size_factors(cds))
 
-      if (!is.null(dim(genes)) && dim(genes) >= 2){
+      if (!is.null(dim(genes)) && ncol(genes) >= 2){
         #genes = as.data.frame(genes)
         #row.names(genes) = genes[,1]
         #genes = genes[row.names(cds_exprs),]


### PR DESCRIPTION
`dim(genes) >= 2` will cause R warning messages; I believe you mean `ncol(genes)` according to the help file.