### PR TITLE
Aggregate genes using the same method as cells

### DIFF
--- a/R/cluster_genes.R
+++ b/R/cluster_genes.R
@@ -484,11 +484,12 @@ aggregate_gene_expression <- function(cds,
       gene_group_df[[1]] <- geneids
     }
     
+    # browser()
     unique_gene_ids <- unique(gene_group_df[, 1])
     agg_mat <- agg_mat[unique_gene_ids, , drop = FALSE]
     gene_groups <- unique(gene_group_df[, 2])
     X <- Matrix::sparseMatrix(
-      i = gene_group_df[, 2],
+      i = match(gene_group_df[, 2], gene_groups),
       j = match(gene_group_df[, 1], unique_gene_ids),
       x = 1,
       dims = c(length(gene_groups), length(unique_gene_ids)),

--- a/R/cluster_genes.R
+++ b/R/cluster_genes.R
@@ -479,33 +479,39 @@ aggregate_gene_expression <- function(cds,
     if (any(short_name_mask)) {
       geneids <- as.character(gene_group_df[[1]])
       geneids[short_name_mask] <- row.names(fData(cds))[match(
-                  geneids[short_name_mask], fData(cds)$gene_short_name)]
+        geneids[short_name_mask], fData(cds)$gene_short_name
+      )]
       gene_group_df[[1]] <- geneids
     }
+    
+    agg_mat <- agg_mat[gene_group_df[, 1], , drop = FALSE]
+    agg_mat <- my.aggregate.Matrix(agg_mat,
+                                   as.factor(gene_group_df[, 2]),
+                                   fun = gene_agg_fun)
 
     # gene_group_df = gene_group_df[row.names(fData(cds)),]
 
     # FIXME: this should allow genes to be part of multiple groups. group_by
     # over the second column with a call to colSum should do it.
-    gene_groups = unique(gene_group_df[,2])
-    agg_gene_groups = lapply(gene_groups, function(gene_group){
-      genes_in_group = unique(gene_group_df[gene_group_df[,2] == gene_group,1])
-      gene_expr_mat = agg_mat[genes_in_group,]
-      if (length(dn <- dim(gene_expr_mat)) < 2L)
-        return(NA)
-      if (gene_agg_fun == "mean"){
-        res = Matrix::colMeans(agg_mat[genes_in_group,])
-      }else if (gene_agg_fun == "sum"){
-        res = Matrix::colSums(agg_mat[genes_in_group,])
-      }
-      return(res)
-    })
+    # gene_groups = unique(gene_group_df[,2])
+    # agg_gene_groups = lapply(gene_groups, function(gene_group){
+    #   genes_in_group = unique(gene_group_df[gene_group_df[,2] == gene_group,1])
+    #   gene_expr_mat = agg_mat[genes_in_group,]
+    #   if (length(dn <- dim(gene_expr_mat)) < 2L)
+    #     return(NA)
+    #   if (gene_agg_fun == "mean"){
+    #     res = Matrix::colMeans(agg_mat[genes_in_group,])
+    #   }else if (gene_agg_fun == "sum"){
+    #     res = Matrix::colSums(agg_mat[genes_in_group,])
+    #   }
+    #   return(res)
+    # })
 
-    agg_mat_colnames = colnames(agg_mat)
-    agg_mat = do.call(rbind, agg_gene_groups)
-    row.names(agg_mat) = gene_groups
-    agg_mat = agg_mat[is.na(agg_gene_groups) == FALSE, , drop=FALSE]
-    colnames(agg_mat) = agg_mat_colnames
+    # agg_mat_colnames = colnames(agg_mat)
+    # agg_mat = do.call(rbind, agg_gene_groups)
+    # row.names(agg_mat) = gene_groups
+    # agg_mat = agg_mat[is.na(agg_gene_groups) == FALSE, , drop=FALSE]
+    # colnames(agg_mat) = agg_mat_colnames
   }
 
   if (is.null(cell_group_df) == FALSE){

--- a/R/cluster_genes.R
+++ b/R/cluster_genes.R
@@ -484,7 +484,6 @@ aggregate_gene_expression <- function(cds,
       gene_group_df[[1]] <- geneids
     }
     
-    # browser()
     unique_gene_ids <- unique(gene_group_df[, 1])
     agg_mat <- agg_mat[unique_gene_ids, , drop = FALSE]
     gene_groups <- unique(gene_group_df[, 2])

--- a/R/cluster_genes.R
+++ b/R/cluster_genes.R
@@ -484,34 +484,20 @@ aggregate_gene_expression <- function(cds,
       gene_group_df[[1]] <- geneids
     }
     
-    agg_mat <- agg_mat[gene_group_df[, 1], , drop = FALSE]
-    agg_mat <- my.aggregate.Matrix(agg_mat,
-                                   as.factor(gene_group_df[, 2]),
-                                   fun = gene_agg_fun)
-
-    # gene_group_df = gene_group_df[row.names(fData(cds)),]
-
-    # FIXME: this should allow genes to be part of multiple groups. group_by
-    # over the second column with a call to colSum should do it.
-    # gene_groups = unique(gene_group_df[,2])
-    # agg_gene_groups = lapply(gene_groups, function(gene_group){
-    #   genes_in_group = unique(gene_group_df[gene_group_df[,2] == gene_group,1])
-    #   gene_expr_mat = agg_mat[genes_in_group,]
-    #   if (length(dn <- dim(gene_expr_mat)) < 2L)
-    #     return(NA)
-    #   if (gene_agg_fun == "mean"){
-    #     res = Matrix::colMeans(agg_mat[genes_in_group,])
-    #   }else if (gene_agg_fun == "sum"){
-    #     res = Matrix::colSums(agg_mat[genes_in_group,])
-    #   }
-    #   return(res)
-    # })
-
-    # agg_mat_colnames = colnames(agg_mat)
-    # agg_mat = do.call(rbind, agg_gene_groups)
-    # row.names(agg_mat) = gene_groups
-    # agg_mat = agg_mat[is.na(agg_gene_groups) == FALSE, , drop=FALSE]
-    # colnames(agg_mat) = agg_mat_colnames
+    unique_gene_ids <- unique(gene_group_df[, 1])
+    agg_mat <- agg_mat[unique_gene_ids, , drop = FALSE]
+    gene_groups <- unique(gene_group_df[, 2])
+    X <- Matrix::sparseMatrix(
+      i = gene_group_df[, 2],
+      j = match(gene_group_df[, 1], unique_gene_ids),
+      x = 1,
+      dims = c(length(gene_groups), length(unique_gene_ids)),
+    )
+    agg_mat <- X %*% agg_mat
+    if (gene_agg_fun == "mean") {
+      agg_mat <- agg_mat / Matrix::rowSums(X)
+    }
+    row.names(agg_mat) <- gene_groups
   }
 
   if (is.null(cell_group_df) == FALSE){


### PR DESCRIPTION
The current method to aggregate genes is very slow, especially when there are many small groups. For example, when I am pseudobulking modules but not TFs, each TF becomes it own "gene group." I don't see a reason why it can't be done using`my.aggregate.Matrix` like what is done for aggregating cells. I constructed a pseudobulk using both methods and the resulting matrices are equal to a tolerance of < 1e-15.