### PR TITLE
Do not set pbmclapply argument ignore.interactive = TRUE in graph_test.

### DIFF
--- a/R/graph_test.R
+++ b/R/graph_test.R
@@ -200,8 +200,7 @@ graph_test <- function(cds,
                  morans_I = NA)
     })
   }, sz = sz, alternative = alternative, method = method,
-  expression_family = expression_family, mc.cores=cores,
-  ignore.interactive = TRUE)
+  expression_family = expression_family, mc.cores=cores)
 
   test_res <- do.call(rbind.data.frame, test_res)
   row.names(test_res) <- row.names(cds)


### PR DESCRIPTION
This avoids the progress bar being printed when rendering a notebook that uses `graph_test`, which tends to spam it with hundreds of lines.