### PR TITLE
fixing #722 (removing grr library as dependency)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,6 @@ Imports:
     ggplot2 (>= 3.1.1),
     ggrastr,
     ggrepel (>= 0.8.1),
-    grr,
     HDF5Array,
     igraph (>= 1.5.0),
     irlba (>= 2.3.3),

--- a/R/cluster_genes.R
+++ b/R/cluster_genes.R
@@ -225,8 +225,29 @@ find_gene_modules <- function(cds,
 }
 
 
-
-
+#' In R 4.6 onwards, grr package fails to compile (#722).
+#' As a stopgap measure, grr::extract function body is copied here.
+#' It is only used once here in my.aggregate.Matrix.
+#' @noRd
+my.extract<-function(x,i=NULL,j=NULL)
+{
+  if(is.null(dim(x)))
+  {
+     x<-x[i]
+    return(x)
+  }
+  else
+    if(!is.null(j))
+      x<-x[,j]
+  if(!is.null(i))
+  {
+  if(is.data.frame(x))
+    x<-as.data.frame(lapply(x,function (a) a[i]))
+  else
+    x<-x[i,]
+  }
+  return(x)
+}
 
 #' Aggregate columns within a sparse matrix.
 #' @noRd
@@ -246,8 +267,10 @@ my.aggregate.Matrix = function (x, groupings = NULL, form = NULL, fun = "sum", .
   result <- Matrix::t(mapping) %*% x
   if (fun == "mean")
     result <- result/as.numeric(table(groupings)[rownames(result)])
-  attr(result, "crosswalk") <- grr::extract(groupings, match(rownames(result),
-                                                             groupings2$A))
+  # R 4.6.0: fixing Issue #722 - removing grr package dependency
+  # attr(result, "crosswalk") <- grr::extract(groupings, match(rownames(result),
+  #                                                           groupings2$A))
+  attr(result, "crosswalk") <- my.extract(groupings, match(rownames(result), groupings2$A)) 
   return(result)
 }
 


### PR DESCRIPTION
As of R 4.6, [grr](https://cran.r-project.org/package=grr) fails to compile. The only function used by monocle3, `grr::extract`, is copy-pasted as-is in cluster_genes.R.