### PR TITLE
Add CLAUDE.md; reduce AGENTS.md to a pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,4 @@
-# Codex instructions (Monocle)
+# See CLAUDE.md
 
-## What this repo is
-Monocle is an R package used in the Trapnell Lab stack for analysis of single-cell perturbation data.
-
-# Codex instructions (Monocle)
-
-Monocle is an R package used in the Trapnell Lab stack for analysis of single-cell perturbation data.
-
-## Cost & safety guardrails
-- Safe to run R package checks and unit tests (minutes).
-- Do NOT run long benchmarks or full-dataset analyses unless explicitly requested.
-- Never commit secrets, credentials, or private datasets.
-
-## Change expectations
-- Prefer small PRs (<300 LOC changed when possible).
-- If changing exported functions, update:
-  - roxygen docs (if used)
-  - tests
-  - NEWS.md (if present)
-- If changing object structures or outputs, add a backward-compat test or a migration note.
-- When adding dependencies, keep them minimal and declare them in `DESCRIPTION`; avoid heavy, non-CRAN dependencies unless justified.
-
-## Validation tiers
-- **FAST (default; safe):** `make fast` (runs `testthat::test_local` with summary reporter; should finish in minutes and not build the package).
-- **SMOKE (opt-in):** Small toy example / vignette using tiny fixtures only.
-- **FULL (manual only):** Real dataset runs / benchmarks.
+Agent instructions for this repo live in `CLAUDE.md`.
+This file is kept only so tools that look for AGENTS.md find the pointer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# monocle3
+
+R package v1.4.29: clustering, DE, and trajectory analysis — the `cell_data_set` (CDS) core the
+whole stack is built on. Upstream of hooke, platt, and zscapetools.
+
+## Commands
+**There is no Makefile here.** Root `make fast` prints `(no Makefile; skipping)` and skips this repo.
+```bash
+Rscript -e 'testthat::test_local(".", reporter="summary")'   # ~24 test files
+Rscript -e 'testthat::test_file("tests/testthat/test-fit_models.R")'   # single file
+R CMD check --no-manual .                                    # the real gate; slow
+```
+
+## Gotchas
+- **Tests branch on a `TRAVIS` env var** to select expected target values and skip interactive
+  code. CI sets `TRAVIS: true`. Results can differ with and without it.
+- `tests/testthat.R` uses `test_check("monocle3")`, which needs the package **installed**;
+  `test_local(".")` is the loop that works against the working tree.
+- `LinkingTo: Rcpp` + `src/` C++ — edits there need a recompile before tests mean anything.
+- ~60 `Imports:` including Bioconductor (`batchelor`, `HDF5Array`, `limma`, `S4Vectors`) and
+  heavy system-dependent packages (`sf`, `spdep`, `leidenbase`, `BPCells`). Adding a dependency
+  here is expensive for every downstream repo.
+- `00travis.yml` is retired notes, not live config.
+
+## Release notes
+`NEWS.md` is the stack's reference format: `# Monocle3 <version>` / `### Changes` / one bullet per
+user-visible change, newest section first. **It currently lags `DESCRIPTION`** — DESCRIPTION is at
+1.4.29, NEWS.md's newest entry is 1.4.25. Write the NEWS entry in the same commit as the bump.
+
+## CI
+`.github/workflows/check_on_push.yml`, `on: [push]`, `R CMD check` in
+`ghcr.io/cole-trapnell-lab/monocle3_depend`. `.github/CODEOWNERS` gates workflow edits.


### PR DESCRIPTION
Replaces the Codex-era AGENTS.md with a CLAUDE.md built from verified repo state. Every build and test command in the new file was confirmed against the Makefile, DESCRIPTION/pyproject and CI config rather than carried over from the old file.

Dropped as stale: the whole 'make fast' / 'make check' tier -- this repo has no Makefile and the stack's fast-all skips it.

AGENTS.md is kept as a four-line pointer so tools that look for it still resolve to the current instructions.